### PR TITLE
Make `be` stack safe partially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 node_js: stable
 install:
   - npm install -g yarn
-  - yarn global add purescript@^0.12.0 pulp@^12.3.0 bower purescript-psa@^0.6.0
+  - yarn global add purescript@^0.13.8 pulp@^15.0.0 bower purescript-psa@^0.7.3
   - export PATH="$PATH:`yarn global bin`"
   - bower install
 script:

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "purescript-prelude": "^4.1.1",
     "purescript-console": "^4.4.0",
     "purescript-lists": "^5.4.1",
-    "purescript-tuples": "^5.1.0"
+    "purescript-tuples": "^5.1.0",
+    "purescript-tailrec": "^4.1.1"
   },
   "devDependencies": {
     "purescript-quickcheck": "^6.1.0",

--- a/bower.json
+++ b/bower.json
@@ -12,15 +12,18 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.0",
-    "purescript-console": "^4.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-tuples": "^5.0.0"
+    "purescript-prelude": "^4.1.1",
+    "purescript-console": "^4.4.0",
+    "purescript-lists": "^5.4.1",
+    "purescript-tuples": "^5.1.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^5.0.0",
-    "purescript-psci-support": "^4.0.0",
-    "purescript-spec": "^3.0.0",
-    "purescript-spec-discovery": "owickstrom/purescript-spec-discovery#a1a8dfd5fadb3f00199d68d20af4bbf56a048c6e"
+    "purescript-quickcheck": "^6.1.0",
+    "purescript-psci-support": "4.0.0",
+    "purescript-spec": "^4.0.1",
+    "purescript-spec-discovery": "^4.0.0"
+  },
+  "resolutions": {
+    "purescript-spec": "^4.0.1"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,9 +3,13 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.Spec.Discovery (discover)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = discover "Test\\.Prettier.Printer\\.*" >>= run [consoleReporter]
+main = do
+  launchAff_ do
+    specs <- discover "Test\\.Prettier.Printer\\.*"
+    runSpec [ consoleReporter ] specs

--- a/test/Prettier/Printer.purs
+++ b/test/Prettier/Printer.purs
@@ -3,11 +3,13 @@ module Test.Prettier.Printer where
 import Prelude
 
 import Control.Monad.Gen (oneOf)
+import Data.Array (foldr, (..))
 import Data.NonEmpty ((:|))
 import Effect.Class (liftEffect)
-import Prettier.Printer (DOC, line, nest, nil, pretty, text)
+import Prettier.Printer (DOC, nest, line, nil, pretty, text)
 import Test.QuickCheck (class Arbitrary, arbitrary, quickCheck, (===))
 import Test.Spec (Spec, describe, it)
+import Test.Spec.Console (write)
 
 newtype DOC' = DOC' DOC
 
@@ -20,6 +22,19 @@ instance arbDOC' :: Arbitrary DOC' where
 
 spec :: Spec Unit
 spec = describe "Prettier.Printer" do
+  describe "overflow" do
+    it "stack safety nest" do
+      let
+        large = foldr (\_ -> nest 0) nil $ 0 .. 1_000_000
+        _ = pretty 0 large
+      pure unit
+    it "stack safety append" do
+      let
+        large = foldr (\_ -> (<>) nil) nil $ 0 .. 1_000_000
+        _ = pretty 0 large
+      pure unit
+    it "stack safety union" do
+      liftEffect $ write "TODO"
   describe "text" do
     it "is a homomorphism from string concatenation to document concatenation" do
       liftEffect $ quickCheck \w s t ->


### PR DESCRIPTION
Related to #11

I haven't solved it completely,
but I think that even a partial solution is useful.

For my use case,
even if `UNION` is not still stack-safe,
it works fine.
(Isn't `UNION` used so much in actual use...?)

Whatever the way,
I would be happy if you could merge any partial improvement.
